### PR TITLE
update `docs/contributing.md` with instructions for populating `.env` file

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,9 +2,10 @@
 
 ## 1. Installation
 1. Fork the repository
-2. Run `npm install`
-3. Run `npm start`
-4. Navigate to `localhost:3000`
+2. Create a `.env` file with the [example.env](./../example.env)
+3. Run `npm install`
+4. Run `npm start`
+5. Navigate to `localhost:3000`
 
 ## 2. Create an Issue
 - Create an issue discussing the feature you want to add or the bug you want to fix.

--- a/example.env
+++ b/example.env
@@ -1,0 +1,4 @@
+MONGO_URI={{URI for Mongo DB}}
+JWT_SECRET={{JWT Secret}}
+JWT_EXPIRES_IN={{Time for token to expire}}
+SESSION_SECRET={{session secret}}


### PR DESCRIPTION
This PR addresses issue #1 

It adds a file, `example.env`, to the root directory and updates the content of `docs/contributing.md` with instructions to follow 